### PR TITLE
Introduced NavigationEventEffect for prioritised onConsume execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+/.idea/

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For this special case, instead of `EventEffect`, you can use the `NavigationEven
 NavigationEventEffect(  
   event = viewState.downloadFailedEvent,  
   onConsumed = viewModel::onConsumedDownloadFailedEvent  
-) { _ ->  
+) {
   navigator.navigateBack()  
 }
 ```

--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ EventEffect(
 The `EventEffect` is a `LaunchedEffect` that will be executed, when the event is in its triggered state. 
 When the event action was executed the effect calls the passed `onConsumed` callback to force you to set the view state field to be consumed.
 
+### Special Case: Navigation
+In the regular way you only want to consume your event when it really got processed. However, in some special cases you want to make sure that the `StateEvent` gets consumed no matter what the outcome of your code that gets triggered will be.
+One case in which that gets relevant is when you want to navigate to another screen, if a `StateEvent` or `StateEventWithContent<T>` got invoked.
+
+For this special case, instead of `EventEffect`, you can use the `NavigationEventEffect`.
+
+```kotlin
+NavigationEventEffect(  
+  event = viewState.downloadFailedEvent,  
+  onConsumed = viewModel::onConsumedDownloadFailedEvent  
+) { _ ->  
+  navigator.navigateBack()  
+}
+```
+
 # Installation
 
 ```gradle

--- a/compose-state-events/src/main/java/de/palm/composestateevents/NavigationEventEffect.kt
+++ b/compose-state-events/src/main/java/de/palm/composestateevents/NavigationEventEffect.kt
@@ -1,0 +1,40 @@
+package de.palm.composestateevents
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+
+/**
+ * Other than the regular [EventEffect] this one will
+ * consume the event before actually executing the action.
+ */
+@Composable
+fun <T> NavigationEventEffect(
+    event: StateEventWithContent<T>,
+    onConsumed: () -> Unit,
+    action: suspend (T) -> Unit
+) {
+    LaunchedEffect(key1 = event, key2 = onConsumed) {
+        if (event is StateEventWithContentTriggered<T>) {
+            onConsumed()
+            action(event.content)
+        }
+    }
+}
+
+/**
+ * Other than the regular [EventEffect] this one will
+ * consume the event before actually executing the action.
+ */
+@Composable
+fun NavigationEventEffect(
+    event: StateEvent,
+    onConsumed: () -> Unit,
+    action: suspend () -> Unit
+) {
+    LaunchedEffect(key1 = event, key2 = onConsumed) {
+        if (event is StateEvent.Triggered) {
+            onConsumed()
+            action()
+        }
+    }
+}

--- a/compose-state-events/src/main/java/de/palm/composestateevents/NavigationEventEffect.kt
+++ b/compose-state-events/src/main/java/de/palm/composestateevents/NavigationEventEffect.kt
@@ -2,28 +2,17 @@ package de.palm.composestateevents
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import kotlin.coroutines.CoroutineContext
 
 /**
+ * A side effect that gets executed when the given [event] changes to its triggered state.
+ *
  * Other than the regular [EventEffect] this one will
  * consume the event before actually executing the action.
- */
-@Composable
-fun <T> NavigationEventEffect(
-    event: StateEventWithContent<T>,
-    onConsumed: () -> Unit,
-    action: suspend (T) -> Unit
-) {
-    LaunchedEffect(key1 = event, key2 = onConsumed) {
-        if (event is StateEventWithContentTriggered<T>) {
-            onConsumed()
-            action(event.content)
-        }
-    }
-}
-
-/**
- * Other than the regular [EventEffect] this one will
- * consume the event before actually executing the action.
+ *
+ * @param event Pass the state event to be listened to from your view-state.
+ * @param onConsumed In this callback you are advised to set the passed [event] to [StateEvent.Consumed] in your view-state.
+ * @param action Callback that gets called in the composition's [CoroutineContext]. Perform the actual action this [event] leads to.
  */
 @Composable
 fun NavigationEventEffect(
@@ -35,6 +24,30 @@ fun NavigationEventEffect(
         if (event is StateEvent.Triggered) {
             onConsumed()
             action()
+        }
+    }
+}
+
+/**
+ * A side effect that gets executed when the given [event] changes to its triggered state.
+ *
+ * Other than the regular [EventEffect] this one will
+ * consume the event before actually executing the action.
+ *
+ * @param event Pass the state event of type [T] to be listened to from your view-state.
+ * @param onConsumed In this callback you are advised to set the passed [event] to an instance of [StateEventWithContentConsumed] in your view-state (see [consumed]).
+ * @param action Callback that gets called in the composition's [CoroutineContext]. Perform the actual action this [event] leads to. The actual content of the [event] will be passed as an argument.
+ */
+@Composable
+fun <T> NavigationEventEffect(
+    event: StateEventWithContent<T>,
+    onConsumed: () -> Unit,
+    action: suspend (T) -> Unit
+) {
+    LaunchedEffect(key1 = event, key2 = onConsumed) {
+        if (event is StateEventWithContentTriggered<T>) {
+            onConsumed()
+            action(event.content)
         }
     }
 }


### PR DESCRIPTION
While working with the Compose State Events library is a great development experience when it comes to handling one-time events, I stumbled upon a drawback.

When implementing navigation in your Android app and navigating to another screen, triggered by an `action` block from the regular `EventEffect`, the `onCosume` function often has no chance to be executed.

This has the effect that when you navigate back from ScreenB to ScreenA, the event that caused the navigation is not consumed correctly and triggers the navigation to ScreenB again.

My suggestion is the `NavigationEventEffect`, which is useful in such situations. The only difference to the regular `EventEffect` is the order of the functions. 

Contrary to the `EventEffect`, here the `onConsume()` is triggered first and then the `action()` block is called. This way you can overcome the timing problem.