### PR TITLE
Add data class to auto generate equals()

### DIFF
--- a/compose-state-events/src/main/java/de/palm/composestateevents/StateEventWithContent.kt
+++ b/compose-state-events/src/main/java/de/palm/composestateevents/StateEventWithContent.kt
@@ -13,7 +13,7 @@ sealed interface StateEventWithContent<out T>
  * @param content A value that is needed on the event consumer side.
  */
 @Immutable
-class StateEventWithContentTriggered<T>(val content: T) : StateEventWithContent<T> {
+data class StateEventWithContentTriggered<T>(val content: T) : StateEventWithContent<T> {
     override fun toString(): String = "triggered($content)"
 }
 


### PR DESCRIPTION
Currently, the `StateEventWithContentTriggered` class does not override equals(), which resorts to object memory addresses when comparing two instances of this class. Data classes automatically generate equals() and hashCode(). This is useful in unit tests, for example, when you want to call assertEquals() on an expected UI state with the actual state returned from the test, and the events are stored as properties within these state classes.