### PR TITLE
Implement AutoConsumeStateEvent

### DIFF
--- a/app/src/main/java/de/palm/composestateeventslib/sample/ui/flower/FlowerScreen.kt
+++ b/app/src/main/java/de/palm/composestateeventslib/sample/ui/flower/FlowerScreen.kt
@@ -1,6 +1,7 @@
 package de.palm.composestateeventslib.sample.ui.flower
 
 import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
@@ -29,7 +31,8 @@ fun FlowerScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(16.dp)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
 
         val viewModel: FlowerScreenViewModel = viewModel()
@@ -48,6 +51,18 @@ fun FlowerScreen(
         EventEffect(
             event = viewState.downloadFailedEvent,
             onConsumed = viewModel::onConsumedDownloadFailedEvent,
+        ) { stringRes ->
+            scaffoldState.snackbarHostState.showSnackbar(context.getString(stringRes))
+        }
+
+        EventEffect(
+            event = viewState.downloadSucceededEvent2,
+        ) {
+            scaffoldState.snackbarHostState.showSnackbar("Success")
+        }
+
+        EventEffect(
+            event = viewState.downloadFailedEvent2,
         ) { stringRes ->
             scaffoldState.snackbarHostState.showSnackbar(context.getString(stringRes))
         }
@@ -71,6 +86,20 @@ fun FlowerScreen(
             onClick = { viewModel.loadFlowersWithFailure() }
         ) {
             Text("Load flowers with failure")
+        }
+
+        Button(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = { viewModel.loadFlowersWithSuccess2() }
+        ) {
+            Text("Load flowers with success (auto-consume)", textAlign = TextAlign.Center)
+        }
+
+        Button(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = { viewModel.loadFlowersWithFailure2() }
+        ) {
+            Text("Load flowers with failure (auto-consume)", textAlign = TextAlign.Center)
         }
 
         LazyColumn {

--- a/app/src/main/java/de/palm/composestateeventslib/sample/ui/flower/FlowerScreenViewModel.kt
+++ b/app/src/main/java/de/palm/composestateeventslib/sample/ui/flower/FlowerScreenViewModel.kt
@@ -2,6 +2,8 @@ package de.palm.composestateeventslib.sample.ui.flower
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import de.palm.composestateevents.AutoConsumeStateEvent
+import de.palm.composestateevents.AutoConsumeStateEventWithContent
 import de.palm.composestateevents.StateEvent
 import de.palm.composestateevents.StateEventWithContent
 import de.palm.composestateevents.consumed
@@ -39,6 +41,19 @@ class FlowerScreenViewModel : ViewModel() {
         }
     }
 
+    fun loadFlowersWithSuccess2() {
+        if (state.isLoading) return
+        viewModelScope.launch {
+            state = state.copy(isLoading = true)
+            delay(2_000L)
+            state = state.copy(
+                isLoading = false,
+                flowers = mockedFlowerList,
+                downloadSucceededEvent2 = triggered
+            )
+        }
+    }
+
     fun loadFlowersWithFailure() {
         if (state.isLoading) return
         viewModelScope.launch {
@@ -47,6 +62,18 @@ class FlowerScreenViewModel : ViewModel() {
             state = state.copy(
                 isLoading = false,
                 downloadFailedEvent = triggered(R.string.flowers_could_not_load)
+            )
+        }
+    }
+
+    fun loadFlowersWithFailure2() {
+        if (state.isLoading) return
+        viewModelScope.launch {
+            state = state.copy(isLoading = true)
+            delay(1_000L)
+            state = state.copy(
+                isLoading = false,
+                downloadFailedEvent2 = triggered(R.string.flowers_could_not_load)
             )
         }
     }
@@ -64,7 +91,10 @@ data class FlowerScreenViewState(
     val isLoading: Boolean = false,
     val flowers: List<Flower> = emptyList(),
     val downloadSucceededEvent: StateEvent = consumed,
-    val downloadFailedEvent: StateEventWithContent<Int> = consumed()
+    val downloadFailedEvent: StateEventWithContent<Int> = consumed(),
+
+    val downloadSucceededEvent2: AutoConsumeStateEvent = consumed,
+    val downloadFailedEvent2: AutoConsumeStateEventWithContent<Int> = consumed()
 )
 
 private val mockedFlowerList = listOf(

--- a/app/src/main/java/de/palm/composestateeventslib/sample/ui/flower_detail/FlowerDeatilScreen.kt
+++ b/app/src/main/java/de/palm/composestateeventslib/sample/ui/flower_detail/FlowerDeatilScreen.kt
@@ -1,6 +1,8 @@
 package de.palm.composestateeventslib.sample.ui.flower_detail
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.Button
 import androidx.compose.material.Text
@@ -8,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import de.palm.composestateevents.NavigationEventEffect
@@ -31,14 +34,32 @@ fun FlowerDetailScreen(
         navController.popBackStack()
     }
 
+    NavigationEventEffect(
+        event = screenState.navBackEvent2,
+    ) {
+        navController.popBackStack()
+    }
+
     Box(modifier = modifier.fillMaxSize()) {
-        Button(
+        Column(
             modifier = Modifier.align(Alignment.Center),
-            onClick = {
-                viewModel.onClickedNavigateBack()
-            }
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            Text(text = "Navigate Back")
+            Button(
+                onClick = {
+                    viewModel.onClickedNavigateBack()
+                }
+            ) {
+                Text(text = "Navigate Back")
+            }
+
+            Button(
+                onClick = {
+                    viewModel.onClickedNavigateBack2()
+                }
+            ) {
+                Text(text = "Navigate Back1")
+            }
         }
     }
 }

--- a/app/src/main/java/de/palm/composestateeventslib/sample/ui/flower_detail/FlowerDetailScreenViewModel.kt
+++ b/app/src/main/java/de/palm/composestateeventslib/sample/ui/flower_detail/FlowerDetailScreenViewModel.kt
@@ -1,19 +1,13 @@
 package de.palm.composestateeventslib.sample.ui.flower_detail
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
+import de.palm.composestateevents.AutoConsumeStateEvent
 import de.palm.composestateevents.StateEvent
-import de.palm.composestateevents.StateEventWithContent
 import de.palm.composestateevents.consumed
-import kotlinx.coroutines.delay
-import de.palm.composestateeventslib.R
 import de.palm.composestateevents.triggered
-import de.palm.composestateeventslib.sample.domain.Flower
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-import java.util.*
 
 class FlowerDetailScreenViewModel : ViewModel() {
 
@@ -33,8 +27,13 @@ class FlowerDetailScreenViewModel : ViewModel() {
     fun onConsumeNavigateBackEvent() {
         state = state.copy(navBackEvent = triggered)
     }
+
+    fun onClickedNavigateBack2() {
+        state = state.copy(navBackEvent2 = triggered)
+    }
 }
 
 data class FlowerDetailScreenViewState(
-    val navBackEvent: StateEvent = consumed
+    val navBackEvent: StateEvent = consumed,
+    val navBackEvent2: AutoConsumeStateEvent = consumed,
 )

--- a/compose-state-events/src/main/java/de/palm/composestateevents/EventEffects.kt
+++ b/compose-state-events/src/main/java/de/palm/composestateevents/EventEffects.kt
@@ -16,7 +16,7 @@ import kotlin.coroutines.CoroutineContext
 @NonRestartableComposable
 fun EventEffect(event: StateEvent, onConsumed: () -> Unit, action: suspend () -> Unit) {
     LaunchedEffect(key1 = event) {
-        if (event is StateEvent.Triggered) {
+        if (event is Triggered) {
             action()
             onConsumed()
         }
@@ -37,6 +37,40 @@ fun <T> EventEffect(event: StateEventWithContent<T>, onConsumed: () -> Unit, act
         if (event is StateEventWithContentTriggered<T>) {
             action(event.content)
             onConsumed()
+        }
+    }
+}
+
+/**
+ *  A side effect that gets executed when the given [event] changes to its triggered state.
+ *
+ *  @param event Pass the state event of type [T] to be listened to from your view-state.
+ *  @param action Callback that gets called in the composition's [CoroutineContext]. Perform the actual action this [event] leads to. The actual content of the [event] will be passed as an argument.
+ */
+@Composable
+@NonRestartableComposable
+fun <T> EventEffect(event: AutoConsumeStateEventWithContent<T>, action: suspend (T) -> Unit) {
+    LaunchedEffect(key1 = event) {
+        if (event is StateEventWithContentTriggered<T> && !event.isConsumed()) {
+            action(event.content)
+            event.consume()
+        }
+    }
+}
+
+/**
+ *  A side effect that gets executed when the given [event] changes to its triggered state.
+ *
+ *  @param event Pass the state event of type [T] to be listened to from your view-state.
+ *  @param action Callback that gets called in the composition's [CoroutineContext]. Perform the actual action this [event] leads to. The actual content of the [event] will be passed as an argument.
+ */
+@Composable
+@NonRestartableComposable
+fun EventEffect(event: AutoConsumeStateEvent, action: suspend () -> Unit) {
+    LaunchedEffect(key1 = event) {
+        if (event is Triggered && !event.isConsumed()) {
+            action()
+            event.consume()
         }
     }
 }

--- a/compose-state-events/src/main/java/de/palm/composestateevents/NavigationEventEffect.kt
+++ b/compose-state-events/src/main/java/de/palm/composestateevents/NavigationEventEffect.kt
@@ -23,7 +23,7 @@ fun NavigationEventEffect(
     action: suspend () -> Unit
 ) {
     LaunchedEffect(key1 = event) {
-        if (event is StateEvent.Triggered) {
+        if (event is Triggered) {
             onConsumed()
             action()
         }
@@ -50,6 +50,52 @@ fun <T> NavigationEventEffect(
     LaunchedEffect(key1 = event) {
         if (event is StateEventWithContentTriggered<T>) {
             onConsumed()
+            action(event.content)
+        }
+    }
+}
+
+/**
+ * A side effect that gets executed when the given [event] changes to its triggered state.
+ *
+ * Other than the regular [EventEffect] this one will
+ * consume the event before actually executing the action.
+ *
+ * @param event Pass the state event of type [T] to be listened to from your view-state.
+ * @param action Callback that gets called in the composition's [CoroutineContext]. Perform the actual action this [event] leads to. The actual content of the [event] will be passed as an argument.
+ */
+@Composable
+@NonRestartableComposable
+fun NavigationEventEffect(
+    event: AutoConsumeStateEvent,
+    action: suspend () -> Unit
+) {
+    LaunchedEffect(key1 = event) {
+        if (event is Triggered && !event.isConsumed()) {
+            event.consume()
+            action()
+        }
+    }
+}
+
+/**
+ * A side effect that gets executed when the given [event] changes to its triggered state.
+ *
+ * Other than the regular [EventEffect] this one will
+ * consume the event before actually executing the action.
+ *
+ * @param event Pass the state event of type [T] to be listened to from your view-state.
+ * @param action Callback that gets called in the composition's [CoroutineContext]. Perform the actual action this [event] leads to. The actual content of the [event] will be passed as an argument.
+ */
+@Composable
+@NonRestartableComposable
+fun <T> NavigationEventEffect(
+    event: AutoConsumeStateEventWithContent<T>,
+    action: suspend (T) -> Unit
+) {
+    LaunchedEffect(key1 = event) {
+        if (event is StateEventWithContentTriggered<T> && !event.isConsumed()) {
+            event.consume()
             action(event.content)
         }
     }

--- a/compose-state-events/src/main/java/de/palm/composestateevents/StateEvent.kt
+++ b/compose-state-events/src/main/java/de/palm/composestateevents/StateEvent.kt
@@ -3,33 +3,53 @@ package de.palm.composestateevents
 import androidx.compose.runtime.Immutable
 
 /**
+ *  This [AutoConsumeStateEvent] can only have two primitive states.
+ *  And, the event will automatically be consumed from effect.
+ */
+
+@Immutable
+sealed interface AutoConsumeStateEvent {
+    fun isConsumed(): Boolean
+    fun consume()
+}
+
+/**
  *  This [StateEvent] can only have two primitive states.
  */
 @Immutable
-sealed interface StateEvent {
-    /**
-     *  The event is currently in its triggered state
-     */
-    @Immutable
-    object Triggered : StateEvent {
-        override fun toString(): String = "triggered"
-    }
+sealed interface StateEvent
 
-    /**
-     *  The event is currently in its consumed state
-     */
-    @Immutable
-    object Consumed : StateEvent {
-        override fun toString(): String = "consumed"
-    }
+/**
+ *  The event is currently in its triggered state
+ */
+@Immutable
+class Triggered : StateEvent, AutoConsumeStateEvent {
+    private var consumed = false
+
+    override fun isConsumed() = consumed
+    override fun consume() { consumed = true }
+
+    override fun toString(): String = "triggered"
+}
+
+/**
+ *  The event is currently in its consumed state
+ */
+@Immutable
+object Consumed : StateEvent, AutoConsumeStateEvent {
+
+    override fun isConsumed() = true
+    override fun consume() { }
+
+    override fun toString(): String = "consumed"
 }
 
 /**
  *  Shorter and more readable version of [StateEvent.Triggered]
  */
-val triggered = StateEvent.Triggered
+val triggered: Triggered get() { return Triggered() }
 
 /**
  *  Shorter and more readable version of [StateEvent.Consumed]
  */
-val consumed = StateEvent.Consumed
+val consumed: Consumed = Consumed

--- a/compose-state-events/src/main/java/de/palm/composestateevents/StateEventWithContent.kt
+++ b/compose-state-events/src/main/java/de/palm/composestateevents/StateEventWithContent.kt
@@ -3,6 +3,18 @@ package de.palm.composestateevents
 import androidx.compose.runtime.Immutable
 
 /**
+ *  This [AutoConsumeStateEventWithContent] can only have two primitive states.
+ *  And, the event will automatically be consumed from effect.
+ *  Additionally, the triggered state holds a value of type [T].
+ */
+
+@Immutable
+sealed interface AutoConsumeStateEventWithContent<out T> {
+    fun isConsumed(): Boolean
+    fun consume()
+}
+
+/**
  *  This [StateEventWithContent] can have exactly 2 states like the [StateEvent] but the triggered state holds a value of type [T].
  */
 @Immutable
@@ -13,7 +25,12 @@ sealed interface StateEventWithContent<out T>
  * @param content A value that is needed on the event consumer side.
  */
 @Immutable
-data class StateEventWithContentTriggered<T>(val content: T) : StateEventWithContent<T> {
+data class StateEventWithContentTriggered<T>(val content: T) : StateEventWithContent<T>, AutoConsumeStateEventWithContent<T> {
+    private var consumed = false
+
+    override fun isConsumed(): Boolean = consumed
+    override fun consume() { consumed = true }
+
     override fun toString(): String = "triggered($content)"
 }
 
@@ -21,7 +38,10 @@ data class StateEventWithContentTriggered<T>(val content: T) : StateEventWithCon
  * The event in its consumed state not holding any value. See [consumed] to create an instance of this.
  */
 @Immutable
-object StateEventWithContentConsumed : StateEventWithContent<Nothing> {
+object StateEventWithContentConsumed : StateEventWithContent<Nothing>, AutoConsumeStateEventWithContent<Nothing> {
+    override fun isConsumed(): Boolean = true
+    override fun consume() {}
+
     override fun toString(): String = "consumed"
 }
 


### PR DESCRIPTION
@leonard-palm Thank you for the library that I love to use.

I made one simple enhancement. It is sometimes annoying to call viewmodel functions to consume the event.
Therefore, I created one more AutoConsumeStateEvent which is automatically consumed without viewmodel function call.

It is fully compatible with the current API and does not break any existing code.

Can you please check it?

CC @Alton09 @octa-one @YanneckReiss 